### PR TITLE
chore(android): remove WRITE_EXTERNAL_STORAGE permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,6 @@ SocialSharing.js is brought in automatically. There is no need to change or add 
 </feature>
 ```
 
-For sharing remote images (or other files) on Android, the file needs to be stored locally first, so add this permission to `AndroidManifest.xml`:
-```xml
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-```
-
 For iOS, you'll need to add the `Social.framework` and `MessageUI.framework` to your project. Click your project, Build Phases, Link Binary With Libraries, search for and add `Social.framework` and `MessageUI.framework`.
 
 2\. Grab a copy of SocialSharing.js, add it to your project and reference it in `index.html`:

--- a/plugin.xml
+++ b/plugin.xml
@@ -79,10 +79,6 @@
       </receiver>
     </config-file>
 
-    <config-file target="AndroidManifest.xml" parent="/*">
-      <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    </config-file>
-
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <provider android:authorities="${applicationId}.sharing.provider" android:exported="false" android:grantUriPermissions="true" android:name="nl.xservices.plugins.FileProvider">
         <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/sharing_paths" />


### PR DESCRIPTION
No ticket, [this permission isn't needed when targeting SDK versions >= 30](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) (we are targettng 33).

The existing of this permission is conflicting with [some other work](https://trello.com/c/FZgRZKp1/810-chore-request-access-to-photo-library-camera-on-android-13) I'm doing.